### PR TITLE
small change on preference UI

### DIFF
--- a/frontend/src/Components/CategoryMappingsModal.tsx
+++ b/frontend/src/Components/CategoryMappingsModal.tsx
@@ -41,9 +41,6 @@ export function CategoryMappingsModal({
                 <Button onClick={() => deleteMapping(mapping.sk)}>
                   Delete
                 </Button>
-                <Button>
-                  Update
-                </Button>
               </ButtonGroup>
             </div>
           )

--- a/frontend/src/Components/CategoryMappingsModal.tsx
+++ b/frontend/src/Components/CategoryMappingsModal.tsx
@@ -1,0 +1,57 @@
+/**
+ *    calling code:
+      <CategoryMappingsModal
+        category={expandedCategory}
+        show={expandedCategory}
+        mappings={mappings.filter(({ category }) => category === expandedCategory)[0].descriptions}
+      />
+ */
+
+import { ButtonGroup, Modal, Button } from "react-bootstrap"
+import { CategoryMappingDescription } from "../api"
+
+
+interface CategoryMappingsModalProps {
+  closeModal: () => void
+  show: boolean
+  mappings: CategoryMappingDescription[]
+  deleteMapping: (sk: string) => Promise<void>
+}
+
+
+export function CategoryMappingsModal({
+  show,
+  closeModal,
+  mappings,
+  deleteMapping,
+}: CategoryMappingsModalProps) {
+  return (
+    <Modal show={show} onHide={closeModal}>
+      <Modal.Header closeButton>
+        <Modal.Title>Related Activities</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="flex flex-col">
+        {mappings.map((mapping) => {
+          return (
+            <div key={mapping.sk} className="flex flex-row justify-between">
+              <div>
+                {mapping.description}
+              </div>
+              <ButtonGroup>
+                <Button onClick={() => deleteMapping(mapping.sk)}>
+                  Delete
+                </Button>
+                <Button>
+                  Update
+                </Button>
+              </ButtonGroup>
+            </div>
+          )
+        })}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={closeModal}>Close</Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/frontend/src/Components/CategoryTrendModal.tsx
+++ b/frontend/src/Components/CategoryTrendModal.tsx
@@ -75,7 +75,7 @@ export function useMonthlyActivities(category: string | null) {
     setLoading(true)
 
     const endDate = new Date(month)
-    endDate.setMonth(endDate.getMonth() + 1, 1)
+    endDate.setMonth(endDate.getMonth() + 2, 0)
 
     getActivities(token, null, {
       size: 10,

--- a/frontend/src/Components/CategoryTrendModal.tsx
+++ b/frontend/src/Components/CategoryTrendModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { Modal } from "react-bootstrap";
+import { Button, Modal } from "react-bootstrap";
 import { getInsights } from "../api";
 import { useAuth0TokenSilent } from "../hooks";
+import { CartesianGrid, Legend, Line, LineChart, Tooltip, XAxis, YAxis } from "recharts";
 
 interface CategoryTrendModalProps {
   show: boolean
@@ -34,7 +35,7 @@ export function CategoryTrendModal(props: CategoryTrendModalProps) {
       return
     }
     const currDate = new Date()
-    const startDate = new Date(currDate.setMonth(currDate.getMonth() - 4))
+    const startDate = new Date(currDate.setMonth(currDate.getMonth() - 6))
     const startDateStr = startDate.toISOString().split('T')[0]
     getInsights(token, startDateStr, [category])
       .then((insights) => {
@@ -56,6 +57,23 @@ export function CategoryTrendModal(props: CategoryTrendModalProps) {
   }, [token, show, category])
 
   return (<Modal show={show} onHide={closeModal}>
-    {JSON.stringify(categoryTrend)}
+    <Modal.Header>
+      <h2>Trends for {category}</h2>
+    </Modal.Header>
+    <Modal.Body>
+      <LineChart width={400} height={400} data={categoryTrend}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey="amount" />
+      </LineChart>
+    </Modal.Body>
+    <Modal.Footer>
+      <Button onClick={closeModal}>
+        Close
+      </Button>
+    </Modal.Footer>
   </Modal>)
 }

--- a/frontend/src/Components/CategoryTrendModal.tsx
+++ b/frontend/src/Components/CategoryTrendModal.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { Modal } from "react-bootstrap";
+import { getInsights } from "../api";
+import { useAuth0TokenSilent } from "../hooks";
+
+interface CategoryTrendModalProps {
+  show: boolean
+  category: string | null
+  closeModal: () => void
+}
+
+interface CategoryStat {
+  month: string
+  amount: number
+}
+
+export function CategoryTrendModal(props: CategoryTrendModalProps) {
+  const {
+    show,
+    category,
+    closeModal
+  } = props
+  const token = useAuth0TokenSilent()
+
+  const [categoryTrend, setCategoryTrend] = useState<CategoryStat[]>([])
+
+  useEffect(() => {
+    if (!show || !category) {
+      setCategoryTrend([])
+      return
+    }
+    if (!token) {
+      console.error('missing auth token')
+      return
+    }
+    const currDate = new Date()
+    const startDate = new Date(currDate.setMonth(currDate.getMonth() - 4))
+    const startDateStr = startDate.toISOString().split('T')[0]
+    getInsights(token, startDateStr, [category])
+      .then((insights) => {
+        setCategoryTrend(insights.map(({start_date, categories}) => {
+          return {
+            month: start_date ?? startDateStr,
+            amount: categories.reduce((amt, breakdown) => {
+              if (breakdown.category === category) {
+                return amt + breakdown.amount
+              }
+              return amt
+            }, 0)
+          }
+        }))
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }, [token, show, category])
+
+  return (<Modal show={show} onHide={closeModal}>
+    {JSON.stringify(categoryTrend)}
+  </Modal>)
+}

--- a/frontend/src/Pages/Preferences/Preferences.tsx
+++ b/frontend/src/Pages/Preferences/Preferences.tsx
@@ -13,25 +13,6 @@ import UpdateMappingModal from '../../Components/UpdateMappingModal'
 import { useAuth0TokenSilent } from '../../hooks'
 import { CategoryMappingsModal } from '../../Components/CategoryMappingsModal'
 
-interface Mapping {
-  sk: string
-  description: string
-  category: string
-}
-
-function transformMappings(mappings: Array<CategoryMapping>) {
-  return mappings.reduce((acc: Mapping[], { category, descriptions }) => {
-    return [
-      ...acc,
-      ...descriptions.map(({ description, sk }) => ({
-        category,
-        description,
-        sk,
-      })),
-    ]
-  }, [])
-}
-
 function deduplicate(arr: Array<string>) {
   return Array.from(new Set(arr))
 }

--- a/frontend/src/Pages/Preferences/Preferences.tsx
+++ b/frontend/src/Pages/Preferences/Preferences.tsx
@@ -12,6 +12,7 @@ import {
 import UpdateMappingModal from '../../Components/UpdateMappingModal'
 import { useAuth0TokenSilent } from '../../hooks'
 import { CategoryMappingsModal } from '../../Components/CategoryMappingsModal'
+import { CategoryTrendModal } from '../../Components/CategoryTrendModal'
 
 function deduplicate(arr: Array<string>) {
   return Array.from(new Set(arr))
@@ -21,12 +22,14 @@ export const Preferences = () => {
   // supports display, update and delete description to category mappings
   const token = useAuth0TokenSilent()
   const [mappings, setMappings] = useState<Array<CategoryMapping>>([])
-  const [showModal, setShowModal] = useState<boolean>(false)
+  const [showNewMappingModal, setShowNewMappingModal] = useState<boolean>(false)
   const [description, setDescription] = useState<string>('')
   const [category, setCategory] = useState<string>('')
   const [allCategories, setAllCategories] = useState<Array<string>>([])
 	const [loading, setLoading] = useState<boolean>(false)
-  const [expandedCategory, setExpandedCategory] = useState<string | null>(null)
+  const [showMappingsForCategory, setShowMappingsForCategory] = useState<string | null>(null)
+  const [showTrendForCategory, setShowTrendForCategory] = useState<string | null>(null)
+
   useEffect(() => {
     if (!token) {
       return
@@ -57,7 +60,7 @@ export const Preferences = () => {
   const openModalWithParams = (desc: string, cat: string) => {
     setDescription(desc)
     setCategory(cat)
-    setShowModal(true)
+    setShowNewMappingModal(true)
   }
   const deleteMappingAndFetch = (sk: string) => {
     // calls delete /mappings endpoint
@@ -120,12 +123,12 @@ export const Preferences = () => {
               <tr key={`${category}${description}`}>
                 <td>{category}</td>
                 <td>
-                  <Button onClick={() => setExpandedCategory(category)}>
+                  <Button onClick={() => setShowMappingsForCategory(category)}>
                     Show Mappings
                   </Button>
                 </td>
                 <td>
-                  <Button>
+                  <Button onClick={() => setShowTrendForCategory(category)}>
                     Show Activities
                   </Button>
                 </td>
@@ -136,19 +139,25 @@ export const Preferences = () => {
       )}
 
       <CategoryMappingsModal
-        show={!!expandedCategory}
-        closeModal={() => setExpandedCategory(null)}
-        mappings={mappings.filter(({ category }) => category === expandedCategory)[0]?.descriptions ?? []}
+        show={!!showMappingsForCategory}
+        closeModal={() => setShowMappingsForCategory(null)}
+        mappings={mappings.filter(({ category }) => category === showMappingsForCategory)[0]?.descriptions ?? []}
         deleteMapping={deleteMappingAndFetch}
       />
 
       <UpdateMappingModal
-        show={showModal}
-        closeModal={() => setShowModal(false)}
+        show={showNewMappingModal}
+        closeModal={() => setShowNewMappingModal(false)}
         currentCategory={category}
         currentDescription={description}
         allCategories={allCategories}
         submit={updateNewCategory}
+      />
+
+      <CategoryTrendModal
+        show={!!showTrendForCategory}
+        category={showTrendForCategory}
+        closeModal={() => setShowTrendForCategory(null)}
       />
     </div>
   )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,7 +7,7 @@ export const API_GATEWAY_URL_MAP: Record<string, string | undefined> = Object.fr
 export const awsLambdaAddr: string = process.env.NODE_ENV ?
   API_GATEWAY_URL_MAP[process.env.NODE_ENV] || '' : ''
 
-interface CategoryMappingDescription {
+export interface CategoryMappingDescription {
   description: string
   sk: string
 }
@@ -107,9 +107,9 @@ function getCall(
   }
 }
 
-function deleteCall(url: string, auth: string): Promise<Response> {
+function deleteCall(url: string, auth: string, params: string[][] = []): Promise<Response> {
   try {
-    return fetch(awsLambdaAddr + url, {
+    return fetch(`${awsLambdaAddr}${url}?${new URLSearchParams(params)}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -219,7 +219,7 @@ export function deleteMapping(
   if (!auth) {
     throw new Error('no auth')
   }
-  return deleteCall(`/mappings?id=${id}`, auth)
+  return deleteCall(`/mappings`, auth, [['id', id]])
 }
 
 export function getActivities(
@@ -377,7 +377,7 @@ export function deleteActivity(auth: string, id: string): Promise<Response> {
   if (!auth) {
     throw new Error('no auth')
   }
-  return deleteCall(`/activities?sk=${id}`, auth)
+  return deleteCall(`/activities`, auth, [['sk', id]])
 }
 
 export interface FileUpload {
@@ -493,7 +493,7 @@ export function deleteWishlistItem(auth: string | null = null, id: string) {
   if (!auth) {
     throw new Error('no auth')
   }
-  return deleteCall(`/wishlist?id=${id}`, auth)
+  return deleteCall(`/wishlist`, auth, [['id', id]])
 }
 
 export function addWishlistItem(

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -403,15 +403,16 @@ export function getUploads(auth: string | null): Promise<Array<FileUpload>> {
     })
 }
 
-export function getInsights(auth: string | null): Promise<Array<Insight>> {
+export function getInsights(auth: string | null, startDate?: string, categories?: string[]): Promise<Array<Insight>> {
   if (!auth) {
     throw new Error('no auth')
   }
   return getCall('/insights', auth, [
-    ['all_categories', 'true'],
+    // TODO: support multiple categories?
+    categories? ['categories', categories[0]] :['all_categories', 'true'],
     ['exclude_negative', 'true'],
     ['by_month', 'true'],
-    ['starting_date', '2023-01-01'] // fix this
+    ['starting_date', startDate ?? '2023-01-01']
   ])
     .then(res => {
       if (res.ok) {


### PR DESCRIPTION
moved mappings to expand in modal, kept delete behavior

todo: 
[x] deleted -  update mapping - this can be done by having the description field as a text box? or just delete the option since I never uses it.
[x] done - see all activities for category - this can be done by adding a modal that shows all of that activities and a chart of trends.